### PR TITLE
ReactQuill Editor's toolbar is hidden onBlur

### DIFF
--- a/sass/components/editor-image/styles.scss
+++ b/sass/components/editor-image/styles.scss
@@ -1,11 +1,34 @@
 .oy-editor-image {
 
+  &__container {
+    background-color: #FFFFFF;
+    border: 1px solid #000;
+  }
+
   &__toolbar {
+    border-bottom: 1px solid gray;
+    background-color: white;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+    padding: 8px;
     margin-bottom: 20px;
 
     button {
+      cursor: pointer;
+      height: 100%;
+      color: #000000;
+      padding: 0 12px;
+      background-color: transparent;
+      font-size: 14px;
+      font-weight: 500;
+
       &.current {
-        background: red;
+        color: #fff;
+        background: $button-bg-color;
+      }
+
+      &:hover {
+        color: #fff;
       }
 
       &:disabled {
@@ -16,10 +39,12 @@
   }
 
   &__caption-container {
-    margin-top: 20px;
+    padding: 12px 15px;
   }
 
   &__image-container {
+    padding: 12px 15px;
+
     &--left {
       text-align: left;
     }

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -3,7 +3,7 @@ body {
   font-size: 14px;
 }
 
-$button-bg-color: #0074d9;
+$button-bg-color: #0065cc;
 
 .btn {
   font: inherit;

--- a/src/components/editor-quill/index.js
+++ b/src/components/editor-quill/index.js
@@ -14,6 +14,9 @@ export class EditorQuill extends React.Component {
 
   constructor(props, context) {
     super(props, context)
+    this.state = {
+      showToolbar: false
+    }
 
     // one can import text, html or the raw delta. Related:
     // - https://github.com/quilljs/quill/issues/1088
@@ -51,18 +54,28 @@ export class EditorQuill extends React.Component {
 
   render() {
     const { block } = this.props
+    const { showToolbar } = this.state
     const currentValue = get(block, 'data.value', '')
 
     return (
       <div {...classes('container')}>
-        <div {...classes('toolbar')} >
-          <QuillToolbar id={block.id} />
+        <div
+          {...classes('toolbar')}
+          style={{
+            display: showToolbar ? 'inherit': 'none'
+          }}
+        >
+          <QuillToolbar
+            id={block.id}
+          />
         </div>
         <div {...classes('editor')} >
           <ReactQuill
             formats={this.formats()}
             modules={this.modules()}
             onChange={this.onChange}
+            onBlur={() => { this.setState({ showToolbar: false }) }}
+            onFocus={() => { this.setState({ showToolbar: true }) }}
             placeholder='Write a text...'
             theme="snow"
             value={currentValue}


### PR DESCRIPTION
## Story

- ReactQuill Editor's toolbar is hidden onBlur ([see diff](https://github.com/lovelysystems/oyez-editor/pull/17/files#diff-8dafbb3d4026eb827c661abc1383ee87))
- Editor-Image Menu adjusted (to fit upcoming style, when all toolbars are merged to look/behave similar) ([see diff](https://github.com/lovelysystems/oyez-editor/pull/17/files#diff-19f49da3009092677633965f1735e5d0))

### Preview

- https://oyez-editor.netlify.com
  
  
  