### PR TITLE
EditorQuill: support for custom parchments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- EditorQuill supports custom parchment formats with `blockConfig.registerFormats`
+  - see example in [editor-quill/index.stories.js](./src/components/editor-quill/index.stories.js)
+
+### Changed
+
+- EditorQuill does not render custom toolbar, when `toolbarOptions` is provided
+  in the `blockConfig`
+
+### Removed
+
+- Removed `hideToolbarOnBlur` feature of EditorQuill, because of [react-quill/issues/276](https://github.com/zenoamaro/react-quill/issues/276#issuecomment-384618178)
+
 ## 2018/12/10 [1.2.0][12]
 
 ### Added

--- a/example/example-app/index.stories.js
+++ b/example/example-app/index.stories.js
@@ -133,10 +133,13 @@ storiesOf('App Example/Customization', module)
       />
     )
   })
-  .add('with a custom blockConfig for the EditorQuill (eg. hidden Toolbar)', () => {
+  .add('with a custom blockConfig for the EditorQuill (eg. toolbarOptions)', () => {
     const editorQuillCustomConfig = merge({}, editorQuillConfig, {
       blockConfig: {
-        hideToolbarOnBlur: true
+        toolbarOptions: [
+          ['bold', 'italic', 'underline', 'strike'],
+          ['clean'],
+        ]
       }
     })
     const blocksConfig = [editorQuillCustomConfig]

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -67,6 +67,16 @@ $bg-color: #eeeeee;
   border: 0;
 }
 
+// custom class styling (inline example parchment)
+.custom-inline-class { 
+  background: #008000;
+  color: #fff;
+  font-size: 1.5em;
+  line-height: 1.75;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
 @import '~font-awesome/css/font-awesome.min.css';
 @import './components/example-menu/styles';
 @import './lovely-editor';

--- a/src/components/editor-quill/README.md
+++ b/src/components/editor-quill/README.md
@@ -53,7 +53,6 @@ props.blockConfig = {
 
 The following data properties are allowed and can be used:
 
-- `hideToolbarOnBlur`: hide the toolbar, once the Editor loses focus (onBlur)
 - `icons`: customize the icons quill renders for the format buttons (eg. for `ql-bold`)
 - `onBlur`, `onFocus`, `onKeyPress`, `onKeyDown`, `onKeyUp`: event listeners
 - `placeholderText`: will overwrite the placeholder text when the editor is empty
@@ -80,7 +79,7 @@ const exampleBlock = {
 }
 
 const blockConfig = {
-  hideToolbarOnBlur: true
+  theme: 'snow'
 }
 
 <EditorQuill

--- a/src/components/editor-quill/index.js
+++ b/src/components/editor-quill/index.js
@@ -24,6 +24,10 @@ export class EditorQuill extends React.Component {
 
     // additionally we register fontawesome icons
     this.registerIcons()
+
+    // register formats and modules _only once_ in the lifetime of this component
+    this.formats = this.getFormats(props)
+    this.modules = this.getModules(props)
   }
 
   // Event Listeners
@@ -148,9 +152,9 @@ export class EditorQuill extends React.Component {
         {this.renderCustomToolbar()}
         <div {...classes('editor', theme)} >
           <ReactQuill
-            formats={this.getFormats(this.props)}
+            formats={this.formats}
+            modules={this.modules}
             placeholder={placeholderText || 'Write a text...'}
-            modules={this.getModules(this.props)}
             onBlur={(previousRange, source, editor) => {
               invoke(this.props, 'blockConfig.onBlur', previousRange, source, editor)
             }}

--- a/src/components/editor-quill/index.js
+++ b/src/components/editor-quill/index.js
@@ -18,22 +18,11 @@ export class EditorQuill extends React.Component {
     super(props, context)
 
     // this component can be customized (eg. custom toolbar) through the `blockConfig` prop
-    //
-    // Example:
-    // props.blockConfig = {
-    //    hideToolbarOnBlur: true
-    // }
-    //
-    // when the user wants to hide the toolbar onBlur, we have to update the
-    // initial state. hideToolbarOnBlur is one of some customization properties
-    this.state = {
-      showToolbar: !get(props, 'blockConfig.hideToolbarOnBlur', false),
-    }
-
     // one can import text, html or the raw delta. Related:
     // - https://github.com/quilljs/quill/issues/1088
     this.onChange = debounce(this.onChange.bind(this), 300, { maxWait: 1000 })
 
+    // additionally we register fontawesome icons
     this.registerIcons()
   }
 
@@ -49,12 +38,19 @@ export class EditorQuill extends React.Component {
 
   /**
    * Quill editor allowed and enabled formats
-   * See https://quilljs.com/docs/formats/
+   * Docs: https://quilljs.com/docs/formats/
+   * Example formats: https://quilljs.com/standalone/full/
    *
-   * Example: https://quilljs.com/standalone/full/
+   * Register custom formats
+   * - https://github.com/zenoamaro/react-quill#custom-formats
+   * - see also editor-qull/index.stories.js for more examples
    */
   getFormats(props) {
     const { blockConfig = {} } = props
+    if (typeof blockConfig.registerFormats === 'function') {
+      return blockConfig.registerFormats(Quill)
+    }
+
     // FYI: undefined or null will enable all formats by default
     return blockConfig.formats
   }
@@ -73,13 +69,15 @@ export class EditorQuill extends React.Component {
    */
   getModules(props) {
     const { block, blockConfig = {} } = props
-    const { modules = {}, toolbarSelector } = blockConfig
+    const { modules = {}, toolbarSelector, toolbarOptions } = blockConfig
+
+    const customToolbar = {
+      container: toolbarSelector || `#toolbar-${block.id}`
+    }
 
     return merge({},
       {
-        toolbar: {
-          container: toolbarSelector || `#toolbar-${block.id}`
-        }
+        toolbar: toolbarOptions || customToolbar
       },
       modules
     )
@@ -105,31 +103,49 @@ export class EditorQuill extends React.Component {
     }
   }
 
-  render() {
-    const { showToolbar } = this.state
+  renderCustomToolbar() {
     const { block, blockConfig = {} } = this.props
-    const { hideToolbarOnBlur, placeholderText, scrollingContainer, toolbarCallback, theme } = blockConfig
-    const currentValue = get(block, 'data.value', '')
+    const { toolbarCallback, toolbarOptions, theme } = blockConfig
+
+    if (toolbarOptions) {
+      /**
+       * if the user provides toolbarOptions, do not render custom toolbar and
+       * use quill's standard toolbar instead
+       * 
+       * example:
+       * 
+       * const toolbarOptions = [
+       *   ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
+       *   ['blockquote', 'code-block'],
+       * ];
+       */
+      return null
+    }
 
     // Toolbar Customization Note:
     // - the user then has to take care of the correct html structures and css
     //   classes to enable the correct react quill toolbar button handling
     const EditorToolbar = get(blockConfig, 'toolbar') || QuillToolbar
+
+    return (
+      <div {...classes('toolbar', theme)} >
+        <EditorToolbar
+          id={block.id}
+          onToolbarClick={toolbarCallback}
+        />
+      </div>
+    )
+  }
+
+  render() {
+    const { block, blockConfig = {} } = this.props
+    const { placeholderText, scrollingContainer, theme } = blockConfig
+    const currentValue = get(block, 'data.value', '')
     const selectedTheme = (theme === 'core') ? null : 'snow' // null = will reset theme
 
     return (
       <div {...classes('container', theme)}>
-        <div
-          {...classes('toolbar', theme)}
-          style={{
-            display: showToolbar ? 'inherit' : 'none'
-          }}
-        >
-          <EditorToolbar
-            id={block.id}
-            onToolbarClick={toolbarCallback}
-          />
-        </div>
+        {this.renderCustomToolbar()}
         <div {...classes('editor', theme)} >
           <ReactQuill
             formats={this.getFormats(this.props)}
@@ -137,17 +153,9 @@ export class EditorQuill extends React.Component {
             modules={this.getModules(this.props)}
             onBlur={(previousRange, source, editor) => {
               invoke(this.props, 'blockConfig.onBlur', previousRange, source, editor)
-
-              if (hideToolbarOnBlur) {
-                this.setState({ showToolbar: false })
-              }
             }}
             onFocus={(range, source, editor) => {
               invoke(this.props, 'blockConfig.onFocus', range, source, editor)
-
-              if (hideToolbarOnBlur) {
-                this.setState({ showToolbar: true })
-              }
             }}
             onChange={this.onChange}
             onKeyDown={(event) => invoke(this.props, 'blockConfig.onKeyDown', event)}
@@ -172,7 +180,6 @@ EditorQuill.propTypes = {
   }).isRequired,
   blockConfig: PropTypes.shape({
     formats: PropTypes.arrayOf(PropTypes.string),
-    hideToolbarOnBlur: PropTypes.bool,
     icons: PropTypes.object,
     onBlur: PropTypes.func,
     onFocus: PropTypes.func,
@@ -180,6 +187,7 @@ EditorQuill.propTypes = {
     onKeyDown: PropTypes.func,
     onKeyUp: PropTypes.func,
     placeholderText: PropTypes.string,
+    registerFormats: PropTypes.func,
     theme: PropTypes.string,
     toolbar: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     toolbarCallback: PropTypes.func,
@@ -190,7 +198,6 @@ EditorQuill.propTypes = {
 EditorQuill.defaultProps = {
   additionalProps: {},
   blockConfig: {
-    hideToolbarOnBlur: false,
     onBlur: () => { },
     onFocus: () => { },
     onKeyPress: () => { },
@@ -198,6 +205,7 @@ EditorQuill.defaultProps = {
     onKeyUp: () => { },
     icons: null,
     placeholderText: 'Write a text...',
+    registerFormats: null,
     toolbar: QuillToolbar,
     toolbarCallback: () => { },
     toolbarSelector: null,

--- a/src/components/editor-quill/index.stories.js
+++ b/src/components/editor-quill/index.stories.js
@@ -165,14 +165,6 @@ storiesOf('Editors/EditorQuill', module)
       <Wrapper block={exampleBlock} blockConfig={blockConfig} />
     )
   })
-  .add('with hideToolbarOnBlur enabled', () => {
-    const blockConfig = {
-      hideToolbarOnBlur: true
-    }
-    return (
-      <Wrapper block={exampleBlock} blockConfig={blockConfig} />
-    )
-  })
   .add('with onBlur, onFocus, onKeyPress, onKeyDown and onKeyUp events', () => {
     const blockConfig = {
       onBlur: action('onBlur'),
@@ -198,7 +190,8 @@ storiesOf('Editors/EditorQuill', module)
         indent: {
           '+1': '<i class="fa fa-indent" aria-hidden="true"></i>',
           '-1': '<i class="fa fa-indent fa-rotate-180" style="padding-top: 2px;" />'
-        }
+        },
+        customFormat: '<i class="fa fa-pencil"/>'
       },
       toolbar: ({ id }) => (
         (
@@ -213,6 +206,7 @@ storiesOf('Editors/EditorQuill', module)
               <button className="ql-list" value="bullet" />
               <button className="ql-indent" value="-1" />
               <button className="ql-indent" value="+1" />
+              <button className="ql-customFormat" />
             </span>
           </div>
         )
@@ -297,5 +291,59 @@ storiesOf('Editors/EditorQuill', module)
     }
     return (
       <Wrapper block={contentBock} />
+    )
+  })
+  .add('with custom parchment styling', () => {
+    /**
+     * inspired by
+     * - https://stackoverflow.com/a/52851287/1238150
+     * - https://stackoverflow.com/a/38723167/1238150 (complex example)
+     * - https://codepen.io/natterstefan/pen/xmZvxe
+     * - https://codepen.io/natterstefan/pen/zyrxzO
+     */
+    const blockConfig = {
+      registerFormats: Quill => {
+        const Inline = Quill.import('blots/inline')
+        const icons = Quill.import('ui/icons')
+
+        class SpanBlock extends Inline {
+
+          static create() {
+            const node = super.create()
+            node.setAttribute('class', 'custom-inline-class')
+            return node
+          }
+
+          static formats() {
+            return true
+          }
+        } // eslint-disable-line
+
+        SpanBlock.blotName = 'customFormat'
+        SpanBlock.tagName = 'span'
+        Quill.register(SpanBlock)
+
+        // https://github.com/quilljs/quill/blob/develop/ui/icons.js
+        icons.customFormat = icons.background
+      },
+      toolbarOptions: [
+        ['bold', 'italic', 'underline', 'strike'],
+        ['customFormat'],
+        ['clean'],
+      ]
+    }
+
+    const contentBock = {
+      id: 5,
+      data: {
+        value: '<p><span class="custom-inline-class">This span has a custom class applied.</span></p><p>Click on the background button to apply the styling or remove it.</p>'
+      },
+      meta: {
+        title: 'Input Box'
+      }
+    }
+
+    return (
+      <Wrapper block={contentBock} blockConfig={blockConfig} />
     )
   })

--- a/src/components/editor-quill/tests/index.spec.js
+++ b/src/components/editor-quill/tests/index.spec.js
@@ -282,27 +282,6 @@ describe('<EditorQuill />', () => {
       expect(blockConfig.onKeyUp.calledOnce).to.equal(true)
       expect(blockConfig.onKeyUp.calledWith({ data: 'some-data' })).to.equal(true)
     })
-
-    it('ReactQuill changes the hideToolbarOnBlur state flag on onBlur or onFocus', () => {
-      const blockConfig = {
-        hideToolbarOnBlur: true
-      }
-      const wrapper = shallow(
-        <EditorQuill
-          block={sampleData}
-          blockConfig={blockConfig}
-          onChange={() => { }}
-        />
-      )
-
-      expect(wrapper.state()).to.equal({ showToolbar: false })
-
-      wrapper.find(ReactQuillComp).prop('onFocus')(1, 'user', {})
-      expect(wrapper.state()).to.equal({ showToolbar: true })
-
-      wrapper.find(ReactQuillComp).prop('onBlur')(1, 'user', {})
-      expect(wrapper.state()).to.equal({ showToolbar: false })
-    })
   })
 
   describe('Custom Toolbar Events', () => {
@@ -320,7 +299,6 @@ describe('<EditorQuill />', () => {
         />
       )
 
-      expect(wrapper.state()).to.equal({ showToolbar: true })
       expect(wrapper.find(customQuillToolbar)).to.have.length(1)
       wrapper.find(customQuillToolbar).dive().find('button').simulate('click')
       expect(customBlockConfig.toolbarCallback.calledOnce).to.equal(true)

--- a/src/components/editor-quill/tests/index.spec.js
+++ b/src/components/editor-quill/tests/index.spec.js
@@ -40,8 +40,7 @@ describe('<EditorQuill />', () => {
   }
 
   describe('Render Tests', () => {
-
-    it('component renders with Toolbar', () => {
+    it('renders with Toolbar', () => {
       const wrapper = render(
         <EditorQuill
           block={sampleData}
@@ -52,7 +51,7 @@ describe('<EditorQuill />', () => {
       expect(wrapper.find('#toolbar-5')).to.have.length(1)
     })
 
-    it('component renders with custom theme', () => {
+    it('renders with custom theme', () => {
       const customBlockConfig = {
         theme: 'core'
       }
@@ -68,7 +67,7 @@ describe('<EditorQuill />', () => {
       expect(wrapper.find('#toolbar-5')).to.have.length(1)
     })
 
-    it('component renders with customToolbar', () => {
+    it('renders with customToolbar', () => {
       const wrapper = render(
         <EditorQuill
           block={sampleData}
@@ -80,10 +79,118 @@ describe('<EditorQuill />', () => {
       expect(wrapper.find('#customToolbar')).to.have.length(1)
     })
 
-    it('attaches a Quill instance to the component', () => {
+    it('renders no customToolbar when toolbarOptions is defined', () => {
+      const customBlockConfig = {
+        toolbar: customQuillToolbar,
+        toolbarOptions: ['bold']
+      }
+      const wrapper = render(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      expect(wrapper.find(customQuillToolbar)).to.have.length(0)
+    })
+
+    it('renders with an attached Quill instance', () => {
       const wrapper = mountReactQuill()
       const quill = getQuillInstance(wrapper)
       expect(quill instanceof Quill).to.equal(true)
+    })
+  })
+
+  describe('Quill Setup', () => {
+    it('prepares formats properly', () => {
+      const customBlockConfig = {
+        formats: [
+          'header',
+          'bold', 'italic', 'underline',
+          'list', 'indent'
+        ],
+      }
+      const wrapper = shallow(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      const instance = wrapper.instance()
+      const result = instance.getFormats({ blockConfig: customBlockConfig })
+      expect(result).to.equal(['header', 'bold', 'italic', 'underline', 'list', 'indent'])
+    })
+
+    it('prepares formtas by invoking registerformats if defined', () => {
+      const customBlockConfig = {
+        registerFormats: sinon.spy()
+      }
+      shallow(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      expect(customBlockConfig.registerFormats.callCount).to.equal(1)
+    })
+
+    it('prepares modules with a default toolbar container selector', () => {
+      const customBlockConfig = {}
+      const wrapper = shallow(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      const instance = wrapper.instance()
+      const result = instance.getModules({ block: sampleData, blockConfig: customBlockConfig })
+      expect(result).to.equal({ toolbar: { container: '#toolbar-5' } })
+    })
+
+    it('prepares modules with a custom toolbarSelector', () => {
+      const customBlockConfig = {
+        toolbarSelector: '#some-id',
+      }
+      const wrapper = shallow(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      const instance = wrapper.instance()
+      const result = instance.getModules({ blockConfig: customBlockConfig })
+      expect(result).to.equal({ toolbar: { container: '#some-id' } })
+    })
+
+    it('prepares modules with provided toolbarOptions and modules', () => {
+      const customBlockConfig = {
+        toolbarOptions: ['bold'],
+        modules: { // see https://quilljs.com/docs/modules/
+          'history': {          // Enable with custom configurations
+            'delay': 2500,
+            'userOnly': true
+          },
+          'syntax': true        // Enable with default configuration
+        }
+      }
+      const wrapper = shallow(
+        <EditorQuill
+          blockConfig={customBlockConfig}
+          block={sampleData}
+          onChange={() => { }}
+        />
+      )
+      const instance = wrapper.instance()
+      const result = instance.getModules({ block: sampleData, blockConfig: customBlockConfig })
+      expect(result).to.equal({
+        toolbar: ['bold'],
+        history: { delay: 2500, userOnly: true },
+        syntax: true
+      })
     })
   })
 


### PR DESCRIPTION
## Example

![screen capture on 2018-12-17 at 10-34-12](https://user-images.githubusercontent.com/1043668/50078450-4fd5de00-01e7-11e9-90bc-9b9803b723b3.gif)

## Links

inspired by

- https://stackoverflow.com/a/52851287/1238150
- https://stackoverflow.com/a/38723167/1238150 (complex example)

other examples

- https://codepen.io/natterstefan/pen/xmZvxe
- https://codepen.io/natterstefan/pen/zyrxzO (template example)